### PR TITLE
implement missing spread

### DIFF
--- a/contexts/casecontroller.js
+++ b/contexts/casecontroller.js
@@ -30,6 +30,7 @@ class InitializedProvider extends React.Component {
     this.pushCharge = () => {
       this.setState({
         caseData: {
+          ...this.state.caseData,
           case: {
             charges: [
               ...this.state.caseData.case.charges,


### PR DESCRIPTION
One of copies in `casecontroller.js` was missing a spread and it was causing the case metadata to fall out of the app state.