### PR TITLE
Implement user input at the charge level

### DIFF
--- a/components/BodyView.js
+++ b/components/BodyView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 
 // components
 import CaseRow from "./CaseRow.js";
@@ -10,18 +10,22 @@ import Grid from "@material-ui/core/Grid";
 
 const useStyles = makeStyles(theme => ({
   body: {
-    marginTop: theme.spacing(12)
+    marginTop: theme.spacing(12),
+    height: '100%'
   }
 }));
 
 function BodyView(props) {
   const classes = useStyles();
   return (
+    <Fragment>
     <div className={classes.body}>
       <Grid>
         <CaseTable />
       </Grid>
     </div>
+    <div>Produced with ❤️ in Washington DC by <a href="https://codefordc.org/"> Code For DC</a></div>
+    </Fragment>
   );
 }
 

--- a/components/CaseRow.js
+++ b/components/CaseRow.js
@@ -1,23 +1,69 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
+import { CaseContext } from "../contexts/casecontroller";
 
 import Collapse from "@material-ui/core/Collapse";
 import IconButton from "@material-ui/core/IconButton";
 import Card from "@material-ui/core/Card";
 import CardHeader from "@material-ui/core/CardHeader";
+import Grid from "@material-ui/core/Grid";
 import CardContent from "@material-ui/core/CardContent";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import TextField from "@material-ui/core/TextField";
+import ComposedDatePicker from "./ComposedDatePicker.js";
+import { Button, FormControlLabel } from "@material-ui/core";
+import Switch from "@material-ui/core/Switch";
 
-const CaseRow = () => {
+const CaseRow = (props) => {
   const [showForm, setShowForm] = useState(false);
+  const value = useContext(CaseContext);
+  
+  // Charge properties
+  const chargeObj = value.caseData.case.charges[props.charge]
+  const [chargeDescription, setChargeDescription] = useState(chargeObj.description);
+  const [chargeClassification, setChargeClassification] = useState(
+    chargeObj.classification
+    );
+  const [chargeIsBRAFelony, setIsBRAFelony] = useState(chargeObj.isBRAFelony);
+  const [chargeIsConvicted, setChargeIsConvicted] = useState(chargeObj.isConvicted);
+  const [chargeIsPapered, setChargeIsPapered] = useState(chargeObj.isPapered);
+  const [chargeOffense, setChargeOffense] = useState(chargeObj.offense);
+  const [chargeDispositionDate, setChargeDispositionDate] = useState(
+    chargeObj.dispositionDate);
 
   const handleExpandClick = () => {
     setShowForm(!showForm);
   };
 
+  const persistWithSetter = (setter, updateValue) => {
+    setter(updateValue)
+    value.updater({
+      caseData: {
+        ...value.caseData,
+        case: {
+          ...value.caseData.case,
+          charges: {
+            ...value.caseData.case.charges,
+            [props.charge]:{
+              description: chargeDescription,
+              classification: chargeClassification,
+              isBRAFelony: chargeIsBRAFelony,
+              isConvicted: chargeIsConvicted,
+              isPapered: chargeIsPapered,
+              dispositionDate: chargeDispositionDate,
+              offense: chargeOffense,
+
+            }
+          }
+        }
+      }
+    })
+
+  }
+
   return (
     <Card>
       <CardHeader
-        title={"Charge"}
+        title={props.charge}
         action={
           <IconButton aria-label="Show form" onClick={handleExpandClick}>
             <ExpandMoreIcon />
@@ -25,7 +71,79 @@ const CaseRow = () => {
         }
       />
       <Collapse in={showForm} timeout="auto" unmountOnExit>
-        {"WOOOT"}
+      <CardContent>
+      <Grid container justify="space-around" direction="column">
+      <TextField
+          id="offense-field"
+          autoComplete='off'
+          label="Offense"
+          value={chargeOffense}
+          onChange={e => persistWithSetter(setChargeOffense, e.target.value)}
+          margin="normal"
+        />
+        <ComposedDatePicker
+          ctxKeys={["caseData", "case", "charges", props.charge]}
+          label={"Disposition Date"}
+          initialDate={chargeDispositionDate}
+          hoist={e => persistWithSetter(setChargeDispositionDate, e)}
+        />
+        <TextField
+          id="classification-field"
+          autoComplete='off'
+          label="Classification"
+          value={chargeClassification}
+          onChange={e => persistWithSetter(setChargeClassification, e.target.value)}
+          margin="normal"
+        />
+        <TextField
+          id="description-field"
+          autoComplete='off'
+          label="Description"
+          value={chargeDescription}
+          onChange={e => persistWithSetter(setChargeDescription, e.target.value)}
+          margin="normal"
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={chargeIsPapered}
+              onChange={
+                e => persistWithSetter(setChargeIsPapered, e.target.checked)
+              }
+              value="ChargeIsPapered"
+              inputProps={{ "aria-label": "ChargeIsPapered checkbox" }}
+            />
+          }
+          label="Is Papered"
+        ></FormControlLabel>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={chargeIsBRAFelony}
+              onChange={
+                e => persistWithSetter(setIsBRAFelony, e.target.checked)
+              }
+              value="ChargeIsBRAFelony"
+              inputProps={{ "aria-label": "ChargeIsBRAFelony checkbox" }}
+            />
+          }
+          label="Is BRA Felony"
+        ></FormControlLabel>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={chargeIsConvicted}
+              onChange={
+                e => persistWithSetter(setChargeIsConvicted, e.target.checked)
+              }
+              value="ChargeIsConvicted"
+              inputProps={{ "aria-label": "ChargeIsConvicted checkbox" }}
+            />
+          }
+          label="Is Convicted"
+        ></FormControlLabel>
+      </Grid>
+      </CardContent>
       </Collapse>
     </Card>
   );

--- a/components/CaseTable.js
+++ b/components/CaseTable.js
@@ -7,12 +7,10 @@ import Card from "@material-ui/core/Card";
 import CardHeader from "@material-ui/core/CardHeader";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import Typography from "@material-ui/core/Typography";
-import Grid from "@material-ui/core/Grid";
 
 // inputs
 import { Button, FormControlLabel } from "@material-ui/core";
 import ComposedDatePicker from "./ComposedDatePicker.js";
-import TextField from "@material-ui/core/TextField";
 import Switch from "@material-ui/core/Switch";
 
 // components

--- a/components/CaseTable.js
+++ b/components/CaseTable.js
@@ -18,6 +18,7 @@ import Switch from "@material-ui/core/Switch";
 // components
 import CaseRow from "./CaseRow";
 import ClientInfoTable from "./ClientInfoTable";
+import EvaluatorInfoTable from "./EvaluatorInfoTable";
 
 const useStyles = makeStyles(theme => ({
   table: {}
@@ -33,18 +34,19 @@ function CaseTable(props) {
         title={<Typography variant="h4">Case Info:</Typography>}
       ></CardHeader>
       <div>
+        <EvaluatorInfoTable />
         <ClientInfoTable />
         {/* Cases in Context object */}
         <div>
-          {value.caseData.case.charges.map((charge, idx) => {
+          {Object.keys(value.caseData.case.charges).map((charge, idx) => {
             return <CaseRow key={`${idx}-chrge`} charge={charge} />;
           })}
         </div>
 
         <CardActionArea
           onClick={() => {
-            console.log(value);
-            value.pushCharge();
+            let chargeNum = Object.keys(value.caseData.case.charges).length
+            value.pushCharge(`Charge ${chargeNum}`);
           }}
         >
           <Typography variant="h6">+ New Charge</Typography>

--- a/components/ClientInfoTable.js
+++ b/components/ClientInfoTable.js
@@ -50,6 +50,7 @@ function ClientInfoTable(props) {
       <Grid container justify="space-around" direction="column">
         <TextField
           id="name-field"
+          autoComplete='off'
           label="Client Name"
           value={clientName}
           onChange={e => setClientName(e.target.value)}
@@ -68,8 +69,9 @@ function ClientInfoTable(props) {
         ></FormControlLabel>
         <TextField
           id="pdid-field"
+          autoComplete='off'
           label="Client PD ID"
-          value={clientName}
+          value={pdId}
           onChange={e => setPdId(e.target.value)}
           margin="normal"
         />

--- a/components/ComposedDatePicker.js
+++ b/components/ComposedDatePicker.js
@@ -39,7 +39,9 @@ function ComposedDatePicker(props) {
         margin="normal"
         id="date-picker-inline"
         label={props.label ? props.label : "Unlabeled Picker"}
+        openTo="year"
         value={dateState}
+        views={["year", "month", "date"]}
         onChange={handleDateChange}
         KeyboardButtonProps={{
           "aria-label": "change date"

--- a/components/EvaluatorInfoTable.js
+++ b/components/EvaluatorInfoTable.js
@@ -1,0 +1,52 @@
+import React, { useState, useContext, Fragment } from "react";
+import { CaseContext } from "../contexts/casecontroller";
+
+// mui
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+
+// inputs
+import { Button, FormControlLabel } from "@material-ui/core";
+import ComposedDatePicker from "./ComposedDatePicker.js";
+import TextField from "@material-ui/core/TextField";
+import Switch from "@material-ui/core/Switch";
+
+// components
+
+const useStyles = makeStyles(theme => ({
+  table: {}
+}));
+
+function EvaluatorInfoTable(props) {
+  const classes = useStyles();
+  const value = useContext(CaseContext);
+  const [name, setName] = useState(value.caseData.evaluatorName);
+  
+  const persist = (name) => {
+    setName(name)
+    value.updater({
+      caseData: {
+        ...value.caseData,
+        evaluatorName: name 
+        }
+    });
+  };
+
+  return (
+    <Fragment>
+      <Typography variant="h5">Evaluator Info:</Typography>
+      <Grid container justify="space-around" direction="column">
+        <TextField
+          id="name-field"
+          label="Evaluator Name"
+          value={name}
+          onChange={e => persist(e.target.value)}
+          margin="normal"
+        />
+        </Grid>
+    </Fragment>
+  );
+}
+
+export default EvaluatorInfoTable;

--- a/contexts/casecontroller.js
+++ b/contexts/casecontroller.js
@@ -30,15 +30,16 @@ class InitializedProvider extends React.Component {
       });
     };
 
-    this.pushCharge = () => {
+    this.pushCharge = (charge) => {
       this.setState({
         caseData: {
           ...this.state.caseData,
           case: {
-            charges: [
+            ...this.state.caseData.case,
+            charges: {
               ...this.state.caseData.case.charges,
-              { ...this.chargeFormat }
-            ]
+              [charge]: {  ...this.state.chargeFormat }
+            }
           }
         }
       });

--- a/libs/template-evaluator.js
+++ b/libs/template-evaluator.js
@@ -1,0 +1,20 @@
+// A template for writing functions to evaluate
+// eligibility.
+// Note: specific charges can be passed for rules that
+// apply at the charge level
+
+function templateEvaluator(caseData, chargeData) {
+
+	// Using the case data, we can, for example
+	// evaluate if a charge is a conviction.
+	console.log(
+		"Is conviction: ", chargeData.isConviction
+		)
+
+	return {
+		"indicator": chargeData.isConviction ? "elligible" : "inelligible",
+		"message": "Template evaluation"
+	};
+}
+
+export default templateEvaluator;

--- a/static/casecontainer.json
+++ b/static/casecontainer.json
@@ -12,8 +12,7 @@
       "id": "",
       "isConvicted": null,
       "terminationDate": "",
-      "charges": [
-      ]
+      "charges": {}
     }
   }
   


### PR DESCRIPTION
- Implementing a variety of features related to user inputs at the individual charges level. 
- Also implement a short note calling out Code For DC.
- Overhauls the `charges` field in the data model (it is now an object). Updates to context methods (particularly pushCharge) were made accordingly.
- Fixes #52 (?), I think we just needed a `height: 100%` near the top of the component hierarchy.