### PR TITLE
Evaluator implementation

### DIFF
--- a/components/BodyView.js
+++ b/components/BodyView.js
@@ -6,12 +6,16 @@ import CaseTable from "./CaseTable.js";
 
 // mui
 import { makeStyles } from "@material-ui/core/styles";
+import Paper from "@material-ui/core/Paper";
+import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 
 const useStyles = makeStyles(theme => ({
   body: {
-    marginTop: theme.spacing(12),
-    height: '100%'
+    marginTop: theme.spacing(5),
+    height: '100%',
+    overflow: 'auto',
+    position: 'relative'
   }
 }));
 
@@ -19,12 +23,12 @@ function BodyView(props) {
   const classes = useStyles();
   return (
     <Fragment>
-    <div className={classes.body}>
-      <Grid>
+    <Container className={classes.body}>
+      <Grid direction='column'>
         <CaseTable />
       </Grid>
-    </div>
     <div>Produced with ❤️ in Washington DC by <a href="https://codefordc.org/"> Code For DC</a></div>
+    </Container>
     </Fragment>
   );
 }

--- a/components/CaseRow.js
+++ b/components/CaseRow.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { CaseContext } from "../contexts/casecontroller";
 
 import Collapse from "@material-ui/core/Collapse";
@@ -34,31 +34,33 @@ const CaseRow = (props) => {
     setShowForm(!showForm);
   };
 
-  const persistWithSetter = (setter, updateValue) => {
-    setter(updateValue)
-    value.updater({
-      caseData: {
-        ...value.caseData,
-        case: {
-          ...value.caseData.case,
-          charges: {
-            ...value.caseData.case.charges,
-            [props.charge]:{
-              description: chargeDescription,
-              classification: chargeClassification,
-              isBRAFelony: chargeIsBRAFelony,
-              isConvicted: chargeIsConvicted,
-              isPapered: chargeIsPapered,
-              dispositionDate: chargeDispositionDate,
-              offense: chargeOffense,
+  useEffect(()=>{
+      value.updater({
+        caseData: {
+          ...value.caseData,
+          case: {
+            ...value.caseData.case,
+            charges: {
+              ...value.caseData.case.charges,
+              [props.charge]:{
+                description: chargeDescription,
+                classification: chargeClassification,
+                isBRAFelony: chargeIsBRAFelony,
+                isConvicted: chargeIsConvicted,
+                isPapered: chargeIsPapered,
+                dispositionDate: chargeDispositionDate,
+                offense: chargeOffense,
 
+              }
             }
           }
         }
-      }
-    })
+      })
+    }, [chargeDescription, chargeClassification, chargeIsBRAFelony,
+    chargeIsConvicted, chargeIsPapered, chargeOffense, chargeDispositionDate]
+  )
 
-  }
+
 
   return (
     <Card>
@@ -78,21 +80,21 @@ const CaseRow = (props) => {
           autoComplete='off'
           label="Offense"
           value={chargeOffense}
-          onChange={e => persistWithSetter(setChargeOffense, e.target.value)}
+          onChange={e => setChargeOffense(e.target.value)}
           margin="normal"
         />
         <ComposedDatePicker
           ctxKeys={["caseData", "case", "charges", props.charge]}
           label={"Disposition Date"}
           initialDate={chargeDispositionDate}
-          hoist={e => persistWithSetter(setChargeDispositionDate, e)}
+          hoist={e => setChargeDispositionDate(e)}
         />
         <TextField
           id="classification-field"
           autoComplete='off'
           label="Classification"
           value={chargeClassification}
-          onChange={e => persistWithSetter(setChargeClassification, e.target.value)}
+          onChange={e => setChargeClassification(e.target.value)}
           margin="normal"
         />
         <TextField
@@ -100,7 +102,7 @@ const CaseRow = (props) => {
           autoComplete='off'
           label="Description"
           value={chargeDescription}
-          onChange={e => persistWithSetter(setChargeDescription, e.target.value)}
+          onChange={e => setChargeDescription(e.target.value)}
           margin="normal"
         />
         <FormControlLabel
@@ -108,7 +110,7 @@ const CaseRow = (props) => {
             <Switch
               checked={chargeIsPapered}
               onChange={
-                e => persistWithSetter(setChargeIsPapered, e.target.checked)
+                e => setChargeIsPapered(e.target.checked)
               }
               value="ChargeIsPapered"
               inputProps={{ "aria-label": "ChargeIsPapered checkbox" }}
@@ -121,7 +123,7 @@ const CaseRow = (props) => {
             <Switch
               checked={chargeIsBRAFelony}
               onChange={
-                e => persistWithSetter(setIsBRAFelony, e.target.checked)
+                e => setIsBRAFelony(e.target.checked)
               }
               value="ChargeIsBRAFelony"
               inputProps={{ "aria-label": "ChargeIsBRAFelony checkbox" }}
@@ -134,7 +136,7 @@ const CaseRow = (props) => {
             <Switch
               checked={chargeIsConvicted}
               onChange={
-                e => persistWithSetter(setChargeIsConvicted, e.target.checked)
+                e => setChargeIsConvicted(e.target.checked)
               }
               value="ChargeIsConvicted"
               inputProps={{ "aria-label": "ChargeIsConvicted checkbox" }}

--- a/components/CaseRow.js
+++ b/components/CaseRow.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useContext, useEffect, Fragment } from "react";
 import { CaseContext } from "../contexts/casecontroller";
 
 import Collapse from "@material-ui/core/Collapse";
@@ -8,9 +8,11 @@ import CardHeader from "@material-ui/core/CardHeader";
 import Grid from "@material-ui/core/Grid";
 import CardContent from "@material-ui/core/CardContent";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import AlbumRoundedIcon from '@material-ui/icons/AlbumRounded';
 import TextField from "@material-ui/core/TextField";
 import ComposedDatePicker from "./ComposedDatePicker.js";
 import { Button, FormControlLabel } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography"
 import Switch from "@material-ui/core/Switch";
 
 const CaseRow = (props) => {
@@ -60,20 +62,44 @@ const CaseRow = (props) => {
     chargeIsConvicted, chargeIsPapered, chargeOffense, chargeDispositionDate]
   )
 
+  const renderIndicator = () => {
+    let chargeData = value.caseData.case.charges[props.charge]
+    if (chargeData.hasOwnProperty('analysis')){
+      console.log("Found an analysis for this charge!")
+      switch (chargeData.analysis.indicator){
+        case "ELIGIBLE":
+          return 'blue';
+        case "INELIGIBLE":
+          return 'red';
+        default:
+          return 'grey';
+      }
+    }
+  }
 
+  const renderAnalysisMessage = () => {
+    let chargeData = value.caseData.case.charges[props.charge]
+    if (chargeData.hasOwnProperty('analysis')){
+      return <Typography>{chargeData.analysis.message}</Typography>
+    }
+  }
 
   return (
     <Card>
       <CardHeader
         title={props.charge}
         action={
+          <Fragment>
+          <AlbumRoundedIcon htmlColor={renderIndicator()}/>
           <IconButton aria-label="Show form" onClick={handleExpandClick}>
             <ExpandMoreIcon />
           </IconButton>
+          </Fragment>
         }
       />
       <Collapse in={showForm} timeout="auto" unmountOnExit>
       <CardContent>
+        {renderAnalysisMessage()}
       <Grid container justify="space-around" direction="column">
       <TextField
           id="offense-field"

--- a/components/ClientInfoTable.js
+++ b/components/ClientInfoTable.js
@@ -27,12 +27,17 @@ function ClientInfoTable(props) {
   );
   const [clientName, setClientName] = useState(value.caseData.client.name);
   const [pdId, setPdId] = useState(value.caseData.client.pdId);
+  const [terminationDate, setTerminationDate] = useState(value.caseData.case.terminationDate);
   // can we get away with omitting pending cases?
 
   const persist = () => {
     value.updater({
       caseData: {
         ...value.caseData,
+        case: {
+          ...value.caseData.case,
+          terminationDate: terminationDate
+        },
         client: {
           ...value.caseData.client,
           dob: dob,
@@ -80,6 +85,12 @@ function ClientInfoTable(props) {
           label={"Client DOB"}
           initialDate={dob}
           hoist={setDob}
+        />
+        <ComposedDatePicker
+          ctxKeys={["caseData", "case", "terminationDate"]}
+          label={"Case Terminated On"}
+          initialDate={new Date()}
+          hoist={setTerminationDate}
         />
       </Grid>
       <Button onClick={persist}>

--- a/contexts/casecontroller.js
+++ b/contexts/casecontroller.js
@@ -1,6 +1,7 @@
 import { createContext } from "react";
 import caseContainer from "../static/casecontainer.json";
 import chargeContainer from "../static/chargecontainer.json";
+import evaluateHelper from "../libs/evaluator.js";
 
 let caseObj = {
   caseData: { ...caseContainer },
@@ -18,7 +19,26 @@ class InitializedProvider extends React.Component {
     super(props);
 
     this.evaluate = () => {
-      // TODO implement rules.json
+      let chargesData = this.state.caseData.case.charges
+      Object.keys(chargesData).map((charge)=>{
+        let analysis = evaluateHelper(this.state.caseData, chargesData[charge])
+        this.setState({
+          caseData:{
+            ...this.state.caseData,
+            case:{
+              ...this.state.caseData.case,
+              charges:{
+                ...this.state.caseData.case.charges,
+                [charge]:{
+                  ...this.state.caseData.case.charges[charge],
+                  analysis: analysis
+                }
+              }
+            }
+          }
+        }, ()=>console.log(this.state))
+      })
+      
     };
 
     // re-initialize
@@ -51,7 +71,8 @@ class InitializedProvider extends React.Component {
     // General purpose updater -- pass an object get a state update
     this.updater = stateobj => {
       this.setState(stateobj, () => {
-        console.log(this.state);
+        // TODO: Move this somewhere that calls much less frequently
+        this.evaluate()
       });
     };
 

--- a/libs/evaluator.js
+++ b/libs/evaluator.js
@@ -1,0 +1,65 @@
+
+function chainAllDeterminations(caseData, chargeData){
+    // a function for collecting the result of all determinations
+    return determineActualInnocence(caseData, chargeData)
+  };
+  
+function determineActualInnocence(caseData, chargeData) {
+    // determines actual innoncence analysis and failing that 
+    // proceeds to interests of justice analysis
+    if (chargeData.isConvicted) {
+        return determineInterestsOfJustice(caseData, chargeData);
+    } else {
+        return fourYearsSinceTermination(caseData, chargeData);
+    }
+}
+  
+function determineInterestsOfJustice(caseData, chargeData){
+    // IoJ has different control flow depending on whether its a felony
+    // Route to appropriate evaluator based on felony
+    switch (chargeData.classification.toLowerCase()) {
+        case "misdemeanor":
+        return determineIoJMisdemeanor(caseData, chargeData);
+        case "felony":
+        return determineIoJFelony(caseData, chargeData);
+        default:
+        return {
+            indicator: null,
+            message: "Cannot determine Interests of Justice analysis without a classification: is it a felony, or a misdemeanor?"
+        }
+    }
+};
+  
+  function determineIoJFelony(caseData, chargeData){
+    return {
+      indicator: null,
+          message: "Cannot determine Interests of Justice analysis for felonies yet"
+    }
+  };
+  
+  function determineIoJMisdemeanor(caseData, chargeData){
+    return {
+      indicator: null,
+          message: "Cannot determine Interests of Justice analysis for misdemeanors yet"
+    }
+  };
+  
+  function fourYearsSinceTermination(caseData, chargeData) {
+    let year = parseInt(caseData.case.terminationDate.split("-")[2]);
+    let today = new Date().getFullYear();
+    let diff = today - year;
+  
+    if (diff > 4) {
+      return {
+        indicator: "ELIGIBLE",
+        message: "Eligible under Actual Innocence Analysis, burden of proof is clear and convincing evidence"
+      }
+    } else {
+      return {
+        indicator: "ELIGIBLE",
+        message: "Eligible under Actual Innocence Analysis, burden of proof is preponderance of evidence"
+      }
+    }
+  }
+
+  export default chainAllDeterminations;

--- a/libs/template-evaluator.js
+++ b/libs/template-evaluator.js
@@ -3,70 +3,21 @@
 // Note: specific charges can be passed for rules that
 // apply at the charge level
 
-let state = {
-  evaluatorName: "Name Nameford Esquire",
-  evaluatorComments: "Some advice to the client",
-  client: {
-    dob: "01-01-1990",
-    isOnProbation: true,
-    name: "Name Namington",
-    pdId: "xyz-123",
-    pendingCases: [{ offense: "22–3225.03a Misdemeanor insurance fraud" }]
-  },
-  case: {
-    id: "docket-XXX-abc-123",
-    isConvicted: false,
-    terminationDate: "02-03-2019",
-    charges: [
-      {
-        classification: "felony",
-        dispositionDate: "01-01-2019",
-        description: "a crime",
-        isBRAFelony: true,
-        isConvicted: true,
-        isPapered: true,
-        offense: "22-401"
-      },
-      {
-        classification: "misdemeanor",
-        description: "a different crime",
-        dispositionDate: "01-01-2019",
-        isBRAFelony: true,
-        isConvicted: false,
-        isPapered: true,
-        offense: "22–3225.03a Misdemeanor insurance fraud"
-      }
-    ]
-  }
-};
+function templateEvaluator(caseData, chargeData) {
+  // Using the case data, we can, for example
+  // evaluate if a charge is a conviction.
+  console.log("Is conviction: ", chargeData.isConviction);
 
-function determineEligibility(state) {
-  if (state.case.isConvicted) {
-    printResult("NOT ELIGIBLE", "This case is NOT ELIGIBLE under 16-802");
-  } else {
-    fourYearsSinceTermination();
-  }
+  return {
+    indicator: chargeData.isConviction ? "elligible" : "inelligible",
+    message: "Template evaluation"
+  };
 }
 
-function fourYearsSinceTermination() {
-  let year = parseInt(state.case.terminationDate.split("-")[2]);
-  let today = new Date().getFullYear();
-  let diff = today - year;
+export default chainAllDeterminations;
 
-  if (diff > 4) {
-    printResult(
-      "ELIGIBLE",
-      "The burden of proof is clear and convincing evidence"
-    );
-  } else {
-    printResult(
-      "ELIGIBLE",
-      "The burden of proof is preponderance of the evidence"
-    );
-  }
-}
-// if BRA return true and return BRA obj
-// BRA obj isConvicted
+// additional example implementations of evaluation methods
+
 function isOtherThanBRA(state) {
   let isBra = state.case.charges.map(charge =>
     charge.isBRAFelony ? true : false
@@ -121,19 +72,52 @@ function printResult(valid, message) {
   console.log(valid, message);
 }
 
-function templateEvaluator(caseData, chargeData) {
-  // Using the case data, we can, for example
-  // evaluate if a charge is a conviction.
-  console.log("Is conviction: ", chargeData.isConviction);
 
-  determineEligibility(state);
-  isOtherThanBRA(state);
-  isAConviction(state);
+// let state = {
+//   evaluatorName: "Name Nameford Esquire",
+//   evaluatorComments: "Some advice to the client",
+//   client: {
+//     dob: "01-01-1990",
+//     isOnProbation: true,
+//     name: "Name Namington",
+//     pdId: "xyz-123",
+//     pendingCases: [{ offense: "22–3225.03a Misdemeanor insurance fraud" }]
+//   },
+//   case: {
+//     id: "docket-XXX-abc-123",
+//     isConvicted: false,
+//     terminationDate: "02-03-2019",
+//     charges: [
+//       {
+//         classification: "felony",
+//         dispositionDate: "01-01-2019",
+//         description: "a crime",
+//         isBRAFelony: true,
+//         isConvicted: true,
+//         isPapered: true,
+//         offense: "22-401"
+//       },
+//       {
+//         classification: "misdemeanor",
+//         description: "a different crime",
+//         dispositionDate: "01-01-2019",
+//         isBRAFelony: true,
+//         isConvicted: false,
+//         isPapered: true,
+//         offense: "22–3225.03a Misdemeanor insurance fraud"
+//       }
+//     ]
+//   }
+// };
 
-  return {
-    indicator: chargeData.isConviction ? "elligible" : "inelligible",
-    message: "Template evaluation"
-  };
-}
 
-export default templateEvaluator;
+// function anyConvictions(caseData){
+  
+//   Object.keys(caseData.case.charges).map((charge)=>{
+//     let chargeObj = caseData.case.charges[charge]
+//     if (chargeObj.isConvicted === true){
+//       return true
+//     }
+//   })
+//   return false
+// }

--- a/pages/index.js
+++ b/pages/index.js
@@ -51,7 +51,7 @@ function Home() {
     <Fragment>
       <CssBaseline />
       <MuiThemeProvider theme={theme}>
-        <div className={classes.root}>
+        <div>
           <InitializedProvider>
             <Nav></Nav>
             <Toolbar />

--- a/static/casecontainer.json
+++ b/static/casecontainer.json
@@ -1,10 +1,10 @@
 {
-    "evaluatorName": "Name Nameford Esquire",
+    "evaluatorName": "Jane Smith Esq",
     "evaluatorComments": "Some advice to the client",
     "client": {
       "dob": "01-01-1990",
       "isOnProbation": true,
-      "name": "Name Namington",
+      "name": "Joe Smith",
       "pdId": "xyz-123",
       "pendingCases": [{ "offense": "22–3225.03a Misdemeanor insurance fraud" }]
     },


### PR DESCRIPTION
* Quick and dirty implementation of the `evaluator` method in the global state object
* I think this finally squashes #52 
* At-a-glance indicators for whether a charge is eligible (needs to migrate to OutcomeIndicator.js component)
* Currently calls `evaluator` on basically every update, we should create an issue to move that somewhere that gets called less frequently
* Implements useEffect in the CaseRow component as state updates were not propagating correctly