### PR TITLE
Added Ziet "now" dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7882,6 +7882,12 @@
       "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
       "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
+    "now": {
+      "version": "16.7.3",
+      "resolved": "https://registry.npmjs.org/now/-/now-16.7.3.tgz",
+      "integrity": "sha512-8jtk6dRmrDd8gBJFWA41BNYV/U1YrSdI+PRJKHb/RLBAN6ZUb+AJeIn0moWwyhLSYhoP0X+nCydcHCKjiRSIsA==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
   "devDependencies": {
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
-    "react-test-renderer": "16.12.0",
     "eslint": "^6.2.2",
     "eslint-plugin-react": "^7.14.3",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
     "lint-staged": "^9.2.4",
+    "now": "^16.7.3",
     "prettier": "^1.18.2",
+    "react-test-renderer": "16.12.0",
     "typescript": "^3.6.3"
   },
   "lint-staged": {


### PR DESCRIPTION
Tiny pull request to pull in the dependencies. This requires a (free) zeit account. I've pushed up the site here:
https://rfjexpungement.doe127960.now.sh/
The workflow would looks like:
After merging in a pull request, run: "now"

The dev deployment will be updated

Solves #78 